### PR TITLE
added customizability to input component

### DIFF
--- a/src/components/Input/Input.module.scss
+++ b/src/components/Input/Input.module.scss
@@ -64,10 +64,10 @@
 }
 
 .translucent {
-  background-color: colors.getColor(neutral-50, null, 0.38);
+  background-color: colors.getColor(neutral-50, null, var(--translucency));
 
   &:focus {
-    background-color: colors.getColor(neutral-50, null, 0.5)
+    background-color: colors.getColor(neutral-50, null, var(--translucency) + 0.12)
   }
 }
 

--- a/src/components/Input/Input.module.scss
+++ b/src/components/Input/Input.module.scss
@@ -64,10 +64,10 @@
 }
 
 .translucent {
-  background-color: colors.getColor(neutral-50, null, var(--translucency));
+  background-color: colors.getColor(neutral-50, null, var(--input-opacity));
 
   &:focus {
-    background-color: colors.getColor(neutral-50, null, 0.5)
+    background-color: colors.getColor(neutral-50, null, var(--input-opacity-on-hover))
   }
 }
 

--- a/src/components/Input/Input.module.scss
+++ b/src/components/Input/Input.module.scss
@@ -9,6 +9,25 @@
   }
 }
 
+.placeholdercolor{
+  @each $color, $_ in colors.$config {
+    &--#{$color} {
+      &::placeholder{
+        color: colors.getColor($color)
+      }
+    }
+  }
+}
+
+.textcolor{
+  @each $color, $_ in colors.$config {
+    &--#{$color} {
+      color: colors.getColor($color)
+    }
+  }
+}
+
+
 .input {
   @include mixins.transition(border-color);
   padding: 0.75rem;
@@ -41,4 +60,17 @@
     border-color: colors.getColor(primary-500);
     background-color: colors.getColor(shades-0);
   }
+  
+}
+
+.translucent {
+  background-color: colors.getColor(neutral-50, null, 0.38);
+
+  &:focus {
+    background-color: colors.getColor(neutral-50, null, 0.5)
+  }
+}
+
+.noborder {
+  border-width: 0px;
 }

--- a/src/components/Input/Input.module.scss
+++ b/src/components/Input/Input.module.scss
@@ -67,7 +67,7 @@
   background-color: colors.getColor(neutral-50, null, var(--translucency));
 
   &:focus {
-    background-color: colors.getColor(neutral-50, null, var(--translucency) + 0.12)
+    background-color: colors.getColor(neutral-50, null, 0.5)
   }
 }
 

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -7,6 +7,14 @@ import styles from './Input.module.scss';
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   /** The default color of the input border */
   outlineColor?: Colors;
+  /** Sets the background to be translucent (2023 website figma) */
+  translucentBackground?: boolean,
+  /** Removes border (2023 website figma) */
+  noBorder?: boolean,
+  /** Changes the color of placeholder text */
+  placeHolderColor?: Colors,
+  /** Changes the color of typed text */
+  textColor?: Colors,
   /** Hides label of input (Only visually) */
   hideLabel?: InputLayoutProps['hideLabel'];
   /** For setting success/error states */
@@ -27,6 +35,10 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
 
 function Input({
   outlineColor = 'shades-0',
+  translucentBackground = false,
+  noBorder = false,
+  placeHolderColor,
+  textColor,
   className,
   hideLabel,
   status,
@@ -60,6 +72,10 @@ function Input({
           className={cx(
               outlineColor && styles[`outline--${outlineColor}`],
               styles.input,
+              translucentBackground && styles.translucent,
+              noBorder && styles.noborder,
+              placeHolderColor && styles[`placeholdercolor--${placeHolderColor}`],
+              textColor && styles[`textcolor--${textColor}`],
           )}
           placeholder={label}
           name={name}

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -7,8 +7,8 @@ import styles from './Input.module.scss';
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   /** The default color of the input border */
   outlineColor?: Colors;
-  /** Sets the background to be translucent (2023 website figma) */
-  translucentBackground?: boolean,
+  /** Translucency from 0 to 100 (2023 website figma), 0 being transparent and 100 being opaque */
+  translucency?: number,
   /** Removes border (2023 website figma) */
   noBorder?: boolean,
   /** Changes the color of placeholder text */
@@ -35,7 +35,7 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
 
 function Input({
   outlineColor = 'shades-0',
-  translucentBackground = false,
+  translucency = 38,
   noBorder = false,
   placeHolderColor,
   textColor,
@@ -52,7 +52,10 @@ function Input({
 }: InputProps) {
   if (status?.state) outlineColor = (status?.state === 'error' ? 'error-500' : 'success');
 
+  const style = { "--translucency": (translucency / 100) } as React.CSSProperties;
+
   return (
+    <div style={style}>
     <InputLayout
       required={props.required}
       className={className}
@@ -72,7 +75,7 @@ function Input({
           className={cx(
               outlineColor && styles[`outline--${outlineColor}`],
               styles.input,
-              translucentBackground && styles.translucent,
+              translucency && styles[`translucent`],
               noBorder && styles.noborder,
               placeHolderColor && styles[`placeholdercolor--${placeHolderColor}`],
               textColor && styles[`textcolor--${textColor}`],
@@ -81,6 +84,7 @@ function Input({
           name={name}
           {...props}/>
     </InputLayout>
+    </div>
   );
 }
 

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -7,9 +7,11 @@ import styles from './Input.module.scss';
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   /** The default color of the input border */
   outlineColor?: Colors;
-  /** Translucency from 0 to 100 (2023 website figma), 0 being transparent and 100 being opaque */
-  translucency?: number,
-  /** Removes border (2023 website figma) */
+  /** Opacity from 0 to 100, 0 being transparent and 100 being opaque */
+  opacity?: number,
+  /** Opacity from 0 to 100 when the input component is focused, 0 being transparent and 100 being opaque */
+  opacityOnHover?: number,
+  /** Removes border */
   noBorder?: boolean,
   /** Changes the color of placeholder text */
   placeHolderColor?: Colors,
@@ -35,7 +37,8 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
 
 function Input({
   outlineColor = 'shades-0',
-  translucency = 38,
+  opacity = 100,
+  opacityOnHover = 100,
   noBorder = false,
   placeHolderColor,
   textColor,
@@ -52,7 +55,12 @@ function Input({
 }: InputProps) {
   if (status?.state) outlineColor = (status?.state === 'error' ? 'error-500' : 'success');
 
-  const style = { "--translucency": (translucency / 100) } as React.CSSProperties;
+  const style = {
+    "--input-opacity": (opacity / 100),
+    "--input-opacity-on-hover": (opacityOnHover / 100)
+  } as React.CSSProperties;
+
+  console.log(style);
 
   return (
     <div style={style}>
@@ -75,7 +83,7 @@ function Input({
           className={cx(
               outlineColor && styles[`outline--${outlineColor}`],
               styles.input,
-              translucency && styles[`translucent`],
+              (opacity !== 100 && opacityOnHover !== 100) && styles[`translucent`],
               noBorder && styles.noborder,
               placeHolderColor && styles[`placeholdercolor--${placeHolderColor}`],
               textColor && styles[`textcolor--${textColor}`],


### PR DESCRIPTION
Added props for **translucent background, no borders, placeholder text color, and text color.**

By default, the translucent background will be 0.38, can enter a number 0 - 100 for 0% to 100% background opacity. On hover, the background will always be 0.5 opacity when a translucent background is in effect.

<img width="1792" alt="Screen Shot 2023-06-19 at 10 47 25 AM" src="https://github.com/hack-the-6ix/react-ui/assets/61566829/f586bb7b-cc26-4c52-a605-3c379d70957f">
<img width="1792" alt="Screen Shot 2023-06-19 at 10 47 20 AM" src="https://github.com/hack-the-6ix/react-ui/assets/61566829/17bacf42-b1c5-4119-811a-a1f339c9058f">
<img width="1792" alt="Screen Shot 2023-06-19 at 10 47 11 AM" src="https://github.com/hack-the-6ix/react-ui/assets/61566829/1fd8f4eb-4b6f-4466-b1e1-bc9a77ab9369">
